### PR TITLE
feat: add Todo modal with editable user (fixes #3)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 
 import React, { useState, useEffect } from 'react'
-
+import TodoList from './components/TodoList'
+import TodoModal from './components/TodoModal'
 
 function App() {
   const STORAGE_KEY = 'todos_v1'
@@ -28,7 +29,7 @@ function App() {
   const addTodo = (e) => {
     if (e && e.preventDefault) e.preventDefault()
     if (input.trim() === '') return
-    setTodos([...todos, { text: input.trim(), done: false }])
+    setTodos([...todos, { text: input.trim(), done: false, user: null }])
     setInput('')
   }
 
@@ -42,6 +43,24 @@ function App() {
 
   const deleteTodo = (idx) => {
     setTodos(todos.filter((_, i) => i !== idx))
+  }
+
+  // Modal state for showing todo details and editing user details
+  const [modalOpen, setModalOpen] = useState(false)
+  const [currentTodoIndex, setCurrentTodoIndex] = useState(null)
+
+  const openModal = (idx) => {
+    setCurrentTodoIndex(idx)
+    setModalOpen(true)
+  }
+
+  const closeModal = () => {
+    setModalOpen(false)
+    setCurrentTodoIndex(null)
+  }
+
+  const saveUserForTodo = (idx, user) => {
+    setTodos(todos.map((t, i) => (i === idx ? { ...t, user } : t)))
   }
 
   return (
@@ -60,20 +79,15 @@ function App() {
         </button>
       </form>
 
-      <ul style={{ listStyle: 'none', padding: 0 }}>
-        {todos.length === 0 && <li style={{ textAlign: 'center', color: '#666' }}>目前沒有待辦事項</li>}
-        {todos.map((todo, idx) => (
-          <li key={idx} style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '8px 0', borderBottom: '1px solid #eee' }}>
-            <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-              <input type="checkbox" checked={todo.done} onChange={() => toggleTodo(idx)} />
-              <span style={{ textDecoration: todo.done ? 'line-through' : 'none' }}>{todo.text}</span>
-            </label>
-            <button onClick={() => deleteTodo(idx)} style={{ background: 'none', border: 'none', color: '#dc2626', cursor: 'pointer' }}>
-              刪除
-            </button>
-          </li>
-        ))}
-      </ul>
+      <TodoList todos={todos} onToggle={toggleTodo} onDelete={deleteTodo} onShow={openModal} />
+
+      {modalOpen && currentTodoIndex !== null && (
+        <TodoModal
+          todo={todos[currentTodoIndex]}
+          onClose={closeModal}
+          onSaveUser={(user) => saveUserForTodo(currentTodoIndex, user)}
+        />
+      )}
     </div>
   )
 }

--- a/src/components/TodoItem.jsx
+++ b/src/components/TodoItem.jsx
@@ -1,0 +1,20 @@
+import React from 'react'
+
+export default function TodoItem({ todo, idx, onToggle, onDelete, onShow }) {
+  return (
+    <li style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: '8px 0', borderBottom: '1px solid #eee' }}>
+      <label style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <input type="checkbox" checked={todo.done} onChange={onToggle} />
+        <span style={{ textDecoration: todo.done ? 'line-through' : 'none' }}>{todo.text}</span>
+      </label>
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+        <button onClick={onShow} style={{ padding: '4px 8px', borderRadius: 4, border: '1px solid #ccc', background: '#fff', cursor: 'pointer' }}>
+          Show
+        </button>
+        <button onClick={onDelete} style={{ background: 'none', border: 'none', color: '#dc2626', cursor: 'pointer' }}>
+          刪除
+        </button>
+      </div>
+    </li>
+  )
+}

--- a/src/components/TodoList.jsx
+++ b/src/components/TodoList.jsx
@@ -1,0 +1,20 @@
+import React from 'react'
+import TodoItem from './TodoItem'
+
+export default function TodoList({ todos, onToggle, onDelete, onShow }) {
+  return (
+    <ul style={{ listStyle: 'none', padding: 0 }}>
+      {todos.length === 0 && <li style={{ textAlign: 'center', color: '#666' }}>目前沒有待辦事項</li>}
+      {todos.map((todo, idx) => (
+        <TodoItem
+          key={idx}
+          idx={idx}
+          todo={todo}
+          onToggle={() => onToggle(idx)}
+          onDelete={() => onDelete(idx)}
+          onShow={() => onShow(idx)}
+        />
+      ))}
+    </ul>
+  )
+}

--- a/src/components/TodoModal.jsx
+++ b/src/components/TodoModal.jsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react'
+import UserForm from './UserForm'
+
+export default function TodoModal({ todo, onClose, onSaveUser }) {
+  // Local editable copy of user so user can type and save
+  const [user, setUser] = useState(todo.user || { name: '', email: '' })
+
+  const handleSave = () => {
+    onSaveUser(user)
+    onClose()
+  }
+
+  return (
+    <div id="todo-modal-root">
+      <div style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.4)', display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        <div style={{ background: '#fff', padding: 20, borderRadius: 8, width: '90%', maxWidth: 480 }}>
+          <button onClick={onClose} style={{ float: 'right', background: 'none', border: 'none', fontSize: 18, cursor: 'pointer' }}>×</button>
+          <h3>Todo Details</h3>
+          <p><strong>Text:</strong> {todo.text}</p>
+          <p><strong>Completed:</strong> {todo.done ? 'Yes' : 'No'}</p>
+
+          <UserForm user={user} onChange={setUser} />
+
+          <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 12 }}>
+            <button onClick={onClose} style={{ padding: '6px 12px', borderRadius: 4 }}>取消</button>
+            <button onClick={handleSave} style={{ padding: '6px 12px', borderRadius: 4, background: '#2563eb', color: '#fff', border: 'none' }}>儲存使用者</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/UserForm.jsx
+++ b/src/components/UserForm.jsx
@@ -1,0 +1,23 @@
+import React from 'react'
+
+export default function UserForm({ user, onChange }) {
+  return (
+    <div style={{ marginTop: 8, paddingTop: 8, borderTop: '1px solid #eee' }}>
+      <h4>使用者資訊</h4>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+        <input
+          value={user.name}
+          onChange={(e) => onChange({ ...user, name: e.target.value })}
+          placeholder="使用者名稱"
+          style={{ padding: 8, borderRadius: 4, border: '1px solid #ccc' }}
+        />
+        <input
+          value={user.email}
+          onChange={(e) => onChange({ ...user, email: e.target.value })}
+          placeholder="電子郵件"
+          style={{ padding: 8, borderRadius: 4, border: '1px solid #ccc' }}
+        />
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
Implements Issue #3: add a modal to view/edit todo details and allow users to input/save user info per todo.\n\nFiles added: src/components/TodoList.jsx, TodoItem.jsx, TodoModal.jsx, UserForm.jsx.\n\nThis PR keeps changes minimal and preserves existing behavior; the modal allows manual user input and saves it on the todo object.\n\nCloses #3.